### PR TITLE
feature: retry configuration for connection db task on Dag from Unive…

### DIFF
--- a/universidades_a/dags/universidades_a.py
+++ b/universidades_a/dags/universidades_a.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+
+default_args = {
+    'email_on_retry': ['matiaspariente@hotmail.com'],
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+}
+
+# Initialization of the DAG for the etl process for universidades_a
+with DAG(
+    'ETL_universidades_a',
+    description='ETL DAG for Universidad de Flores and Villa Maria',
+    detault_args=default_args,
+    schedule_interval=timedelta(hours=1),
+    start_date=datetime.now(),
+) as dag:
+
+    # Operator that will extract universidad de Flores data with SQL query
+    extract_flores = DummyOperator(
+        task_id='extract_SQLquery_flores',
+        retries=5
+        )
+
+    # Operator that will extract universidad de Villa Maria data with SQL query
+    extract_villa_maria = DummyOperator(
+        task_id='extract_SQLquery_villa_maria',
+        retries=5
+        )


### PR DESCRIPTION
Tarea: https://alkemy-labs.atlassian.net/browse/OT214-36

Resumen: Se configuraron los retries para la tarea que hará la conexión con la base de datos.

Aclaraciones: Entiendo que la tarea no pide la conexión a la base de datos si no que solo configurar los retries para la tarea que ejecute dicha conexión, en este caso seria la tarea de extract de ambas universidades. Si bien se configuro por defecto para que todas las tareas que tengan 1 retry, específicamente a las tareas de extract que serán las con las cuales se hará la conexión a la base de datos se le configuro que tenga 5 retries cada un minuto en el caso de fallar y se envié un correo en caso de que esto suceda.  Para probar el codigo se hizo un merge manual con el pull request pendiente de configuración de dags funcionando con exito.