### PR TITLE
feature:logger_config-OT214-46 config .yaml file and logging_config.p…

### DIFF
--- a/universidades_c/dags/config/logging_config.py
+++ b/universidades_c/dags/config/logging_config.py
@@ -1,0 +1,14 @@
+import logging
+import logging.config
+
+import yaml
+
+
+def logging_configuration(_path='./logging_config.yaml'):
+
+    with open(_path, 'rt') as f:
+        config = yaml.safe_load(f.read())
+        logging.config.dictConfig(config)
+        logger = logging.getLogger('__name__')
+
+    return logger

--- a/universidades_c/dags/config/logging_config.yaml
+++ b/universidades_c/dags/config/logging_config.yaml
@@ -12,7 +12,7 @@ handlers:
     info_file_handler:
         class: logging.FileHandler
         level: INFO
-        filename: universidades_c/dags/main.log
+        filename: ./OT214-Python/universidades_c/dags/main.log
         formatter: standard
         encoding: utf8
 

--- a/universidades_c/dags/config/logging_config.yaml
+++ b/universidades_c/dags/config/logging_config.yaml
@@ -1,0 +1,28 @@
+version: 1
+disable_existing_loggers: true
+
+formatters:
+    standard:
+        class: logging.Formatter
+        style:  "%"
+        datefmt: "%d-%b-%y"
+        format: "%(asctime)s - %(name)s - %(message)s"
+
+handlers:
+    info_file_handler:
+        class: logging.FileHandler
+        level: INFO
+        filename: /OT214-Python/universidades_c/dags/main.log
+        formatter: standard
+        encoding: utf8
+
+root:
+    level: INFO
+    handlers: [info_file_handler]
+
+loggers:
+    sampleLogger:
+        level: INFO
+        handlers: [info_file_handler]
+        formatter: standard
+        propogate: no

--- a/universidades_c/dags/config/logging_config.yaml
+++ b/universidades_c/dags/config/logging_config.yaml
@@ -12,7 +12,7 @@ handlers:
     info_file_handler:
         class: logging.FileHandler
         level: INFO
-        filename: /OT214-Python/universidades_c/dags/main.log
+        filename: universidades_c/dags/main.log
         formatter: standard
         encoding: utf8
 


### PR DESCRIPTION
…y files created for university_c
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT214/boards/287?modal=detail&selectedIssue=OT214-46

- logging_config.yaml file with dictConfig data created
- logging_config.py to use .yaml file and define the logger configuration created
- logging_configuration() function must be imported to each DAG file and injected as op_args to each operation that wishes to have logs into a main.log file.
- Both files were tested locally with airflow server successfully
<img width="2410" alt="Captura de Pantalla 2022-05-26 a la(s) 16 51 41" src="https://user-images.githubusercontent.com/98064909/170566613-93cdb85d-88c9-497c-ba93-faa39e964780.png">
 