### PR TITLE
feature: Logging configuration using .cfg file created OT-214-118

### DIFF
--- a/datos_c/config/logging.cfg
+++ b/datos_c/config/logging.cfg
@@ -1,0 +1,40 @@
+[loggers]
+keys=root,console,fileRotating
+
+[handlers]
+keys=consoleHandler, fileRotatingHandler
+
+[formatters]
+keys=standard
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[logger_console]
+level=INFO
+handlers=consoleHandler
+qualname=consoleHandler
+
+[logger_fileRotating]
+level=INFO
+handlers=fileRotatingHandler
+qualname=fileRotating
+propagate=0
+
+[handler_consoleHandler]
+class=logging.StreamHandler
+level=INFO
+formatter=standard
+
+[handler_fileRotatingHandler]
+class=logging.handlers.TimedRotatingFileHandler
+formatter=standard
+args=('./logs/datos_c.log', 'D', 7)
+# encoding=utf-8
+
+[formatter_standard]
+class=logging.Formatter
+style=%
+datefmt=%Y-%m-%d
+format=%(asctime)s-%(levelname)s-%(name)s-%(message)s

--- a/datos_c/logs/datos_c.log
+++ b/datos_c/logs/datos_c.log
@@ -1,0 +1,3 @@
+2022-06-13-INFO-fileRotating-Test message
+2022-06-13-INFO-fileRotating-Test message
+2022-06-13-INFO-fileRotating-Test message


### PR DESCRIPTION
Logging configuration using .cfg file created, one console logger, and one TimeRotatingFile logger with an interval of 7 days, according to the required format.
Code was tested locally with successful results for an interval of 3 minutes. 

https://alkemy-labs.atlassian.net/jira/software/c/projects/OT214/boards/287?modal=detail&selectedIssue=OT214-118


